### PR TITLE
Passing scope and fixed config file references

### DIFF
--- a/src/Auth/LoginProxy.php
+++ b/src/Auth/LoginProxy.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 namespace Olymbytes\Z00s\Auth;
 
@@ -62,7 +62,7 @@ class LoginProxy
 
     /**
      * Get access token.
-     * 
+     *
      * @return object
      */
     protected function getAccessToken()
@@ -72,7 +72,7 @@ class LoginProxy
 
     /**
      * Get the client credentials from the provider.
-     * 
+     *
      * @return array
      */
     protected function getClientCredentials($user)
@@ -84,12 +84,13 @@ class LoginProxy
         return [
             'client_id'     => $credentials->getClientId(),
             'client_secret' => $credentials->getClientSecret(),
+            'scope'         => $credentials->getScope(),
         ];
     }
 
     /**
      * Get the user instance.
-     * 
+     *
      * @return object
      */
     protected function getUserInstance()
@@ -100,7 +101,7 @@ class LoginProxy
 
     /**
      * Get username field from the config.
-     * 
+     *
      * @return string
      */
     protected function getUsernameField()

--- a/src/Z00sServiceProvider.php
+++ b/src/Z00sServiceProvider.php
@@ -15,10 +15,10 @@ class Z00sServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->publishes([
-            __DIR__.'/../config/olymbytes-z00s.php' => config_path('olymbytes-z00s.php'),
+            __DIR__.'/../config/z00s.php' => config_path('z00s.php'),
         ], 'config');
 
-        $this->mergeConfigFrom(__DIR__ . '/../config/olymbytes-z00s.php', 'olymbytes-z00s');
+        $this->mergeConfigFrom(__DIR__ . '/../config/z00s.php', 'z00s');
 
         $this->loadRoutesFrom(__DIR__ . '/routes.php');
     }


### PR DESCRIPTION
Scope now included when getting and passing the client credentials via the proxy.

Also included fix of service provider's config file references.

Looks like IDE trimmed trailing whitespace and added newline at EOF.